### PR TITLE
Compose screenshots with drop shadow

### DIFF
--- a/Demo/DemoApp/DemoAppApp.swift
+++ b/Demo/DemoApp/DemoAppApp.swift
@@ -15,6 +15,7 @@ struct DemoAppApp: App {
             })
             .background(Color("BackgroundColor"))
             .frame(width: 650, height: 500, alignment: .top)
+            .walkthroughImageStyle(.screenshot)
         }
         .windowResizability(.contentSize)
         .windowStyle(.hiddenTitleBar)

--- a/Sources/MarkWalkthrough/MarkWalkthroughWindow.swift
+++ b/Sources/MarkWalkthrough/MarkWalkthroughWindow.swift
@@ -8,6 +8,8 @@ public struct MarkWalkthroughWindow: View {
     @ObservedObject var viewModel: MarkWalkthroughModel
     @State var controlsDisabled = false
 
+    @Environment(\.walkthroughImageStyle) var walkthroughImageStyle
+
     public init(viewModel: MarkWalkthroughModel, closeAction: @escaping () -> Void) {
         self.viewModel = viewModel
         self.closeAction = closeAction
@@ -21,7 +23,7 @@ public struct MarkWalkthroughWindow: View {
                     if viewModel.currentStep.isMultiple(of: 2) {
                         if let name = viewModel.evenImageName {
                             Image(name)
-                                .walkthroughStyle(.screenshot)
+                                .walkthroughStyle(walkthroughImageStyle)
                                 .transition(
                                     .asymmetric(
                                         insertion: viewModel.evenAddTransition,
@@ -33,7 +35,7 @@ public struct MarkWalkthroughWindow: View {
                     } else {
                         if let name = viewModel.oddImageName {
                             Image(name)
-                                .walkthroughStyle(.screenshot)
+                                .walkthroughStyle(walkthroughImageStyle)
                                 .transition(
                                     .asymmetric(
                                         insertion: viewModel.oddAddTransition,
@@ -46,7 +48,8 @@ public struct MarkWalkthroughWindow: View {
 
                     if let name = viewModel.stickerImageName {
                         Image(name)
-                            .walkthroughStyle(.none)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
                             .frame(width: 500)
                             .scaleEffect(viewModel.stickerScale, anchor: .center)
                             .offset(x: viewModel.stickerOffset[0], y: viewModel.stickerOffset[1])

--- a/Sources/MarkWalkthrough/MarkWalkthroughWindow.swift
+++ b/Sources/MarkWalkthrough/MarkWalkthroughWindow.swift
@@ -21,8 +21,7 @@ public struct MarkWalkthroughWindow: View {
                     if viewModel.currentStep.isMultiple(of: 2) {
                         if let name = viewModel.evenImageName {
                             Image(name)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
+                                .walkthroughStyle(.screenshot)
                                 .transition(
                                     .asymmetric(
                                         insertion: viewModel.evenAddTransition,
@@ -34,8 +33,7 @@ public struct MarkWalkthroughWindow: View {
                     } else {
                         if let name = viewModel.oddImageName {
                             Image(name)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
+                                .walkthroughStyle(.screenshot)
                                 .transition(
                                     .asymmetric(
                                         insertion: viewModel.oddAddTransition,
@@ -48,8 +46,7 @@ public struct MarkWalkthroughWindow: View {
 
                     if let name = viewModel.stickerImageName {
                         Image(name)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
+                            .walkthroughStyle(.none)
                             .frame(width: 500)
                             .scaleEffect(viewModel.stickerScale, anchor: .center)
                             .offset(x: viewModel.stickerOffset[0], y: viewModel.stickerOffset[1])

--- a/Sources/MarkWalkthrough/WalkthroughImageStyle.swift
+++ b/Sources/MarkWalkthrough/WalkthroughImageStyle.swift
@@ -1,7 +1,42 @@
 import SwiftUI
 
-enum WalkthroughImageStyle {
+public enum WalkthroughImageStyleEnvironmentKey: EnvironmentKey {
+    public static var defaultValue: WalkthroughImageStyle = .none
+}
+
+extension EnvironmentValues {
+    public var walkthroughImageStyle: WalkthroughImageStyle {
+        get { self[WalkthroughImageStyleEnvironmentKey.self] }
+        set { self[WalkthroughImageStyleEnvironmentKey.self] = newValue }
+    }
+}
+
+extension View {
+    /// Sets the ``WalkthroughImageStyle`` in the environment to `newStyle`.
+    @inlinable
+    @ViewBuilder
+    public func walkthroughImageStyle(_ newStyle: WalkthroughImageStyle) -> some View {
+        environment(\.walkthroughImageStyle, newStyle)
+    }
+}
+
+extension Scene {
+    /// Sets the ``WalkthroughImageStyle`` in the environment to `newStyle`.
+    @inlinable
+    @SceneBuilder
+    public func walkthroughImageStyle(_ newStyle: WalkthroughImageStyle) -> some Scene {
+        self.environment(\.walkthroughImageStyle, newStyle)
+    }
+}
+
+
+// MARK: -
+
+public enum WalkthroughImageStyle {
+    /// Shows the image to fit the window without any decoration.
     case none
+
+    /// Shows the image to fit the window with a drop shadow, ideal for app screenshots.
     case screenshot
 }
 

--- a/Sources/MarkWalkthrough/WalkthroughImageStyle.swift
+++ b/Sources/MarkWalkthrough/WalkthroughImageStyle.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+enum WalkthroughImageStyle {
+    case none
+    case screenshot
+}
+
+extension Image {
+    @ViewBuilder
+    func walkthroughStyle(_ style: WalkthroughImageStyle) -> some View {
+        self.resizable()
+            .aspectRatio(contentMode: .fit)
+            .modifier(style.modifier)
+    }
+}
+
+// MARK: - ViewModifier
+
+extension WalkthroughImageStyle {
+    fileprivate var modifier: some ViewModifier { StyleModifier(style: self) }
+}
+
+fileprivate struct StyleModifier: ViewModifier {
+    let style: WalkthroughImageStyle
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        switch style {
+        case .none:
+            content
+        case .screenshot:
+            content.modifier(ScreenshotModifier())
+        }
+    }
+}
+
+fileprivate struct ScreenshotModifier: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        content.shadow(color: .init(white: 0, opacity: 0.1), radius: 20)
+            .shadow(color: .init(white: 0, opacity: 0.1), radius: 8, y: 2)
+    }
+}


### PR DESCRIPTION
This PR adds a `WalkthroughImageStyle` enum to apply a consistent style to the walkthrough assets. My goal is to make screenshots look better by adding a drop shadow.

|  | Old and busted | New hotness |
| -- | -- | -- |
| Interesting color scheme | <img width="762" alt="2023-12-05 11-08-32 DemoApp - DemoApp@2x" src="https://github.com/icanzilb/MarkWalkthrough/assets/59080/490bd013-5b24-440b-a2e5-41db6c7eabdd"> | <img width="762" alt="2023-12-05 11-08-24 DemoApp - DemoApp@2x" src="https://github.com/icanzilb/MarkWalkthrough/assets/59080/1a2936c2-07c3-42f9-8cf3-c4a52f8ca160"> |
| Classic color scheme | <img width="762" alt="2023-12-05 11-07-46 DemoApp - DemoApp@2x" src="https://github.com/icanzilb/MarkWalkthrough/assets/59080/7a98ba1c-24a6-4924-bfa2-bede81c4e2c1"> | <img width="762" alt="2023-12-05 11-07-59 DemoApp - DemoApp@2x" src="https://github.com/icanzilb/MarkWalkthrough/assets/59080/62ec78dd-0c67-45e7-9c59-5f924ede6a92"> |

I believe the demo app's BG color is not white to demonstrate custom colors, so I didn't change it in this PR although I believe it's not doing the attractiveness of the pics a favor :)


## Caveat / Why it's a Draft

### How to detect screenshots?

I don't think this is ready for prime time unless (a) all pictures are considered being screenshots (for now?), or (b) the data model is expanded to include a 'style' or content type column so that e.g. screenshots get the shadow but icons or graphs/charts/visualizations don't

### Broken transition masks

The `Wipe` transition computes a mask that doesn't (and maybe cannot?) take any shadow into account and cuts it off at the corners.

It doesn't get better if the shadow is applied later, either. The image-with-shadow would probably need to report a larger intrinsic size for the wipe effect to work. But then the image would sit weirdly in the window.

See here:

| Good example | Wipe example |
| - | - | 
| <img width="650" alt="2023-12-05 10-55-11 DemoApp - DemoApp@2x" src="https://github.com/icanzilb/MarkWalkthrough/assets/59080/0dd3fe9f-dc78-49f3-8c2b-943532f8d5e9"> | <img width="650" alt="2023-12-05 10-55-07 DemoApp - DemoApp@2x" src="https://github.com/icanzilb/MarkWalkthrough/assets/59080/2d2f4fa0-c22a-45e6-8477-f66403b22e4a"> |
